### PR TITLE
Fix io stream closing leak

### DIFF
--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -120,7 +120,7 @@ public class ExportJob {
     ensureHandle();
     exported = true;
 
-    LOG.info("Exporting graphic from: " + url);
+    LOG.info("Exporting graphic from: {}", url);
 
     final DevToolsDriver chrome = fetchChrome();
     try {
@@ -134,7 +134,7 @@ public class ExportJob {
 
       name = handle + ".png";
       exportResult = chrome.screenshot();
-    } catch (final Exception e) {
+    } catch (final RuntimeException e) {
       LOG.error("Unrecoverable failure while sending snapshot job to chrome instance.", e);
       throw new RuntimeException("Could not finish web document snapshot.", e);
     } finally {
@@ -166,7 +166,7 @@ public class ExportJob {
 
       name = handle + ".pdf";
       exportResult = chrome.pdf(printParams);
-    } catch (final Exception e) {
+    } catch (final RuntimeException e) {
       LOG.error("Unrecoverable failure while sending print job to chrome instance.", e);
       throw new RuntimeException("Could not finish PDF export.", e);
     } finally {
@@ -208,6 +208,7 @@ public class ExportJob {
       try {
         Thread.sleep(4000);
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         // Eat
       }
     });

--- a/src/main/java/nl/aerius/print/QuittableChrome.java
+++ b/src/main/java/nl/aerius/print/QuittableChrome.java
@@ -38,7 +38,7 @@ public class QuittableChrome extends DevToolsDriver {
 
     // Fetch the page ID
     id = res.jsonPath("$.id").asString();
-    LOG.info("Page ID created: ", id);
+    LOG.info("Page ID created: {}", id);
 
     activate();
     enablePageEvents();
@@ -79,10 +79,13 @@ public class QuittableChrome extends DevToolsDriver {
 
   @Override
   public void quit() {
-    LOG.info("Closing page ID " + id);
-
-    final Http http = options.getHttp();
-    Command.waitForHttp(http.urlBase);
-    http.path("json", "close", id).get();
+    try {
+      LOG.info("Closing page ID: {}", id);
+      final Http http = options.getHttp();
+      Command.waitForHttp(http.urlBase);
+      http.path("json", "close", id).get();
+    } finally {
+      super.quit();
+    }
   }
 }


### PR DESCRIPTION
QuittableChrome overrides quit, but doesn't call the super method quit,
which causes the websocket client to remain open.