### PR TITLE
Update karate version to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <karate.intuit.version>0.9.5</karate.intuit.version>
+    <karate.intuit.version>1.2.0</karate.intuit.version>
     <itext.version>7.0.4</itext.version>
 
     <aerius-tools.version>1.1.1</aerius-tools.version>
@@ -83,17 +83,6 @@
     <dependency>
       <groupId>com.intuit.karate</groupId>
       <artifactId>karate-core</artifactId>
-      <version>${karate.intuit.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.intuit.karate</groupId>
-      <artifactId>karate-apache</artifactId>
       <version>${karate.intuit.version}</version>
       <exclusions>
         <exclusion>

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -25,10 +25,9 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.intuit.karate.Config;
 import com.intuit.karate.FileUtils;
+import com.intuit.karate.core.Config;
 import com.intuit.karate.driver.DevToolsDriver;
-import com.intuit.karate.driver.MissingElement;
 
 import nl.aerius.pdf.TimeoutException;
 
@@ -192,7 +191,7 @@ public class ExportJob {
   public ExportJob completeOrFailViaIndicator() {
     return waitForComplete(chrome -> {
       chrome.waitForAny("#complete-indicator", "#failure-indicator");
-      if (!(chrome.exists("#failure-indicator") instanceof MissingElement)) {
+      if (chrome.exists("#failure-indicator")) {
         // Assume we're crashing with a TimeoutException (for now)
         throw new TimeoutException();
       }

--- a/src/main/resources/nl/aerius/print/dummy.feature
+++ b/src/main/resources/nl/aerius/print/dummy.feature
@@ -1,0 +1,3 @@
+Feature: Some dummy feature
+
+Scenario: Some dummy scenario


### PR DESCRIPTION
Latest and greatest, and an actual release version (0.9.5 was still in development).
Does need some changes, and most noticable is the need to construct a ScenarioRuntime which turned out to require quite some instantiation as nullpointers would occur without it.
Karate is more meant for testing purposes, so the way we use it needs some extra work... but it works (at least for me locally).
Does require the timeout to be specified as an integer instead of a long (warning for at least AERIUS-II).