### PR TITLE
Fix finding dummy file in jar

### DIFF
--- a/src/main/java/nl/aerius/print/QuittableChrome.java
+++ b/src/main/java/nl/aerius/print/QuittableChrome.java
@@ -87,7 +87,7 @@ public class QuittableChrome extends DevToolsDriver {
   private static synchronized ScenarioRuntime createRuntime() {
     if (ScenarioEngine.get() == null) {
       // Use the bare minimum to construct a runtime/engine.
-      final Feature dummyFeature = Feature.read(QuittableChrome.class.getResource("dummy.feature").toString());
+      final Feature dummyFeature = Feature.read("classpath:/nl/aerius/print/dummy.feature");
       final FeatureRuntime featureRuntime = FeatureRuntime.of(Suite.forTempUse(HttpClientFactory.DEFAULT), dummyFeature, null);
       final FeatureSection section = new FeatureSection();
       section.setIndex(-1);


### PR DESCRIPTION
As it was, karate's ResourceUtils wouldn't find the dummy feature file in a jar. It would work if you'd have the project in your workspace and started debugging in Eclipse, but since that's not usually the case...