### PR TITLE
Adding itext bouncy-castle-adapter dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>layout</artifactId>
       <version>${itext.version}</version>
     </dependency>
+    <dependency>
+    	<groupId>com.itextpdf</groupId>
+    	<artifactId>bouncy-castle-adapter</artifactId>
+    	<version>${itext.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
See https://kb.itextpdf.com/itext/bouncy-castle-changes, there's a choice between 2, and one of them has to be picked. To avoid the impression that we know what FIPS are, went with the non-specific one.