### PR TITLE
Add an explicit FailureIndicatorException failure mode

### DIFF
--- a/src/main/java/nl/aerius/pdf/FailureIndicatorException.java
+++ b/src/main/java/nl/aerius/pdf/FailureIndicatorException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.pdf;
+
+/**
+ * Exception thrown when a failure indicator is found in the exported document.
+ */
+public class FailureIndicatorException extends RuntimeException {
+  public FailureIndicatorException() {
+    super();
+  }
+
+  public FailureIndicatorException(final String message) {
+    super(message);
+  }
+
+  public FailureIndicatorException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}
+
+

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -30,7 +30,7 @@ import com.intuit.karate.FileUtils;
 import com.intuit.karate.core.Config;
 import com.intuit.karate.driver.DevToolsDriver;
 
-import nl.aerius.pdf.TimeoutException;
+import nl.aerius.pdf.FailureIndicatorException;
 
 public class ExportJob {
   private static final Logger LOG = LoggerFactory.getLogger(ExportJob.class);
@@ -163,16 +163,16 @@ public class ExportJob {
 
   public ExportJob completeOrFailViaIndicator() {
     return waitForComplete(chrome -> {
-      chrome.waitForAny("#complete-indicator", "#failure-indicator");
-      if (chrome.exists("#failure-indicator")) {
-        // Assume we're crashing with a TimeoutException (for now)
-        throw new TimeoutException();
+      chrome.waitFor("#complete-indicator");
+      if (chrome.exists("#complete-indicator.failure")) {
+        throw new FailureIndicatorException();
       }
     });
   }
 
+  @Deprecated
   public ExportJob completeViaIndicator() {
-    return waitForComplete(chrome -> chrome.waitFor("#complete-indicator"));
+    return completeOrFailViaIndicator();
   }
 
   public ExportJob completeViaSleep() {


### PR DESCRIPTION
The FailureIndicatorException exception is explicitly thrown when the failure indicator is found.

Furthermore, the failure mode is now `#complete-indicator` + `failure` class, rather than `#failure-indicator`. (the former is what is actually used upstream)