### PR TITLE
Rich failure logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
       <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -133,6 +139,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -142,20 +142,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>

--- a/src/main/java/nl/aerius/pdf/TimeoutException.java
+++ b/src/main/java/nl/aerius/pdf/TimeoutException.java
@@ -18,4 +18,16 @@ package nl.aerius.pdf;
 
 public class TimeoutException extends RuntimeException {
   private static final long serialVersionUID = 1L;
+
+  public TimeoutException() {
+    super();
+  }
+
+  public TimeoutException(final String message) {
+    super(message);
+  }
+
+  public TimeoutException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -289,8 +289,8 @@ public class ExportJob {
 
   private void fail(final QuittableChrome chrome, final String failurePhase, final Throwable cause) {
     for (final NetworkFailure failure : chrome.getNetworkFailures()) {
-      LOG.warn("Network failure during {}: url={} error={} status={} body={}",
-          failurePhase, failure.url(), failure.errorText(), failure.responseStatus(), failure.responseBody());
+      LOG.warn("Network failure during {}: url={} error={} status={} referer={} body={}",
+          failurePhase, failure.url(), failure.errorText(), failure.responseStatus(), failure.referer(), failure.responseBody());
     }
     if (failureHook != null) {
       failureHook.accept(chrome, url, failurePhase, cause);

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -55,6 +55,8 @@ public class ExportJob {
 
   private boolean saved;
 
+  private boolean trackNetworkFailures;
+
   // Hooks for custom behavior on complete and failure before the driver quits
   private DriverHook completeHook;
   private DriverHook failureHook;
@@ -208,6 +210,12 @@ public class ExportJob {
     return this;
   }
 
+  public ExportJob trackNetworkFailures() {
+    checkExported();
+    this.trackNetworkFailures = true;
+    return this;
+  }
+
   private void waitForComplete(final DevToolsDriver driver) {
     waitForComplete.accept(driver);
   }
@@ -237,7 +245,7 @@ public class ExportJob {
     options.put("headless", true);
     options.put("host", host);
 
-    final QuittableChrome chrome = QuittableChrome.prepareAndStart(options);
+    final QuittableChrome chrome = QuittableChrome.prepareAndStart(options, trackNetworkFailures);
     chrome.retry(retryCount);
 
     return chrome;

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -210,9 +210,9 @@ public class ExportJob {
     return this;
   }
 
-  public ExportJob trackNetworkFailures() {
+  public ExportJob trackNetworkFailures(final boolean trackNetworkFailures) {
     checkExported();
-    this.trackNetworkFailures = true;
+    this.trackNetworkFailures = trackNetworkFailures;
     return this;
   }
 

--- a/src/main/java/nl/aerius/print/ExportJob.java
+++ b/src/main/java/nl/aerius/print/ExportJob.java
@@ -231,7 +231,7 @@ public class ExportJob {
     return exportResult;
   }
 
-  private DevToolsDriver fetchChrome() {
+  private QuittableChrome fetchChrome() {
     final Map<String, Object> options = new HashMap<>(driverOptions);
     options.put("start", false);
     options.put("headless", true);
@@ -245,7 +245,7 @@ public class ExportJob {
 
   private byte[] runExport(final boolean useSleepWait, final Function<DevToolsDriver, byte[]> exporter,
       final String failurePhase) {
-    final DevToolsDriver chrome = fetchChrome();
+    final QuittableChrome chrome = fetchChrome();
     try {
       chrome.setUrl(url);
 
@@ -279,7 +279,11 @@ public class ExportJob {
     }
   }
 
-  private void fail(final DevToolsDriver chrome, final String failurePhase, final Throwable cause) {
+  private void fail(final QuittableChrome chrome, final String failurePhase, final Throwable cause) {
+    for (final NetworkFailure failure : chrome.getNetworkFailures()) {
+      LOG.warn("Network failure during {}: url={} error={} status={} body={}",
+          failurePhase, failure.url(), failure.errorText(), failure.responseStatus(), failure.responseBody());
+    }
     if (failureHook != null) {
       failureHook.accept(chrome, url, failurePhase, cause);
     }

--- a/src/main/java/nl/aerius/print/NetworkFailure.java
+++ b/src/main/java/nl/aerius/print/NetworkFailure.java
@@ -23,5 +23,6 @@ public record NetworkFailure(
     String resourceType,
     boolean canceled,
     Integer responseStatus,
-    String responseBody) {
+    String responseBody,
+    String referer) {
 }

--- a/src/main/java/nl/aerius/print/NetworkFailure.java
+++ b/src/main/java/nl/aerius/print/NetworkFailure.java
@@ -14,23 +14,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.pdf;
+package nl.aerius.print;
 
-/**
- * Exception thrown when a failure indicator is found in the exported document.
- */
-public class FailureIndicatorException extends TimeoutException {
-  public FailureIndicatorException() {
-    super();
-  }
-
-  public FailureIndicatorException(final String message) {
-    super(message);
-  }
-
-  public FailureIndicatorException(final String message, final Throwable cause) {
-    super(message, cause);
-  }
+public record NetworkFailure(
+    String url,
+    String method,
+    String errorText,
+    String resourceType,
+    boolean canceled,
+    Integer responseStatus,
+    String responseBody) {
 }
-
-

--- a/src/main/java/nl/aerius/print/NetworkFailureTracker.java
+++ b/src/main/java/nl/aerius/print/NetworkFailureTracker.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class NetworkFailureTracker {
   private static final Logger LOG = LoggerFactory.getLogger(NetworkFailureTracker.class);
 
-  private record RequestData(String url, String method) {}
+  private record RequestData(String url, String method, String referer) {}
   private record FailureData(String requestId, String errorText, String resourceType, boolean canceled) {}
 
   private final Map<String, RequestData> requests = new ConcurrentHashMap<>();
@@ -38,9 +38,9 @@ public class NetworkFailureTracker {
   private final List<FailureData> failures = new CopyOnWriteArrayList<>();
   private final Set<String> httpErrorRequestIds = ConcurrentHashMap.newKeySet();
 
-  public void onRequest(final String requestId, final String url, final String method) {
+  public void onRequest(final String requestId, final String url, final String method, final String referer) {
     if (requestId != null) {
-      requests.put(requestId, new RequestData(url, method));
+      requests.put(requestId, new RequestData(url, method, referer));
     }
   }
 
@@ -65,8 +65,9 @@ public class NetworkFailureTracker {
     }
 
     final RequestData req = requestId != null ? requests.get(requestId) : null;
-    LOG.warn("Network request failed: url={} error={} type={} canceled={}",
-        req != null ? req.url() : "unknown", errorText, resourceType, isCanceled);
+    LOG.warn("Network request failed: url={} error={} type={} canceled={} referer={}",
+        req != null ? req.url() : "unknown", errorText, resourceType, isCanceled,
+        req != null ? req.referer() : "unknown");
   }
 
   public List<NetworkFailure> getFailures(final Function<String, String> bodyFetcher) {
@@ -84,7 +85,8 @@ public class NetworkFailureTracker {
           failure.resourceType(),
           failure.canceled(),
           status,
-          body));
+          body,
+          req != null ? req.referer() : null));
     }
 
     // HTTP error responses (4xx/5xx) that didn't also trigger loadingFailed
@@ -99,7 +101,8 @@ public class NetworkFailureTracker {
           null,
           false,
           status,
-          body));
+          body,
+          req != null ? req.referer() : null));
     }
 
     return result;

--- a/src/main/java/nl/aerius/print/NetworkFailureTracker.java
+++ b/src/main/java/nl/aerius/print/NetworkFailureTracker.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.print;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NetworkFailureTracker {
+  private static final Logger LOG = LoggerFactory.getLogger(NetworkFailureTracker.class);
+
+  private record RequestData(String url, String method) {}
+  private record FailureData(String requestId, String errorText, String resourceType, boolean canceled) {}
+
+  private final Map<String, RequestData> requests = new ConcurrentHashMap<>();
+  private final Map<String, Integer> responseStatuses = new ConcurrentHashMap<>();
+  private final List<FailureData> failures = new CopyOnWriteArrayList<>();
+  private final Set<String> httpErrorRequestIds = ConcurrentHashMap.newKeySet();
+
+  public void onRequest(final String requestId, final String url, final String method) {
+    if (requestId != null) {
+      requests.put(requestId, new RequestData(url, method));
+    }
+  }
+
+  public void onResponse(final String requestId, final Integer status) {
+    if (requestId != null && status != null) {
+      responseStatuses.put(requestId, status);
+      if (status >= 400) {
+        httpErrorRequestIds.add(requestId);
+        final RequestData req = requests.get(requestId);
+        LOG.warn("HTTP error response: url={} status={}",
+            req != null ? req.url() : "unknown", status);
+      }
+    }
+  }
+
+  public void onLoadingFailed(final String requestId, final String errorText, final String resourceType, final Boolean canceled) {
+    final boolean isCanceled = canceled != null && canceled;
+    failures.add(new FailureData(requestId, errorText, resourceType, isCanceled));
+    // Remove from httpErrorRequestIds to avoid duplicate reporting
+    if (requestId != null) {
+      httpErrorRequestIds.remove(requestId);
+    }
+
+    final RequestData req = requestId != null ? requests.get(requestId) : null;
+    LOG.warn("Network request failed: url={} error={} type={} canceled={}",
+        req != null ? req.url() : "unknown", errorText, resourceType, isCanceled);
+  }
+
+  public List<NetworkFailure> getFailures(final Function<String, String> bodyFetcher) {
+    final List<NetworkFailure> result = new ArrayList<>();
+
+    // Network-level failures (loadingFailed)
+    for (final FailureData failure : failures) {
+      final RequestData req = failure.requestId() != null ? requests.get(failure.requestId()) : null;
+      final Integer status = failure.requestId() != null ? responseStatuses.get(failure.requestId()) : null;
+      final String body = bodyFetcher.apply(failure.requestId());
+      result.add(new NetworkFailure(
+          req != null ? req.url() : "unknown",
+          req != null ? req.method() : "unknown",
+          failure.errorText(),
+          failure.resourceType(),
+          failure.canceled(),
+          status,
+          body));
+    }
+
+    // HTTP error responses (4xx/5xx) that didn't also trigger loadingFailed
+    for (final String requestId : httpErrorRequestIds) {
+      final RequestData req = requests.get(requestId);
+      final Integer status = responseStatuses.get(requestId);
+      final String body = bodyFetcher.apply(requestId);
+      result.add(new NetworkFailure(
+          req != null ? req.url() : "unknown",
+          req != null ? req.method() : "unknown",
+          null,
+          null,
+          false,
+          status,
+          body));
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/nl/aerius/print/QuittableChrome.java
+++ b/src/main/java/nl/aerius/print/QuittableChrome.java
@@ -44,10 +44,15 @@ public class QuittableChrome extends DevToolsDriver {
   private static final Logger LOG = LoggerFactory.getLogger(QuittableChrome.class);
 
   private final String id;
-  private final NetworkFailureTracker networkFailureTracker = new NetworkFailureTracker();
+  private final boolean trackNetworkFailures;
+  private final NetworkFailureTracker networkFailureTracker;
 
-  public QuittableChrome(final Response res, final DriverOptions options, final Command command, final String webSocketUrl) {
+  public QuittableChrome(final Response res, final DriverOptions options, final Command command, final String webSocketUrl,
+      final boolean trackNetworkFailures) {
     super(options, command, webSocketUrl);
+
+    this.trackNetworkFailures = trackNetworkFailures;
+    this.networkFailureTracker = trackNetworkFailures ? new NetworkFailureTracker() : null;
 
     // Fetch the page ID
     id = res.json().get("$.id");
@@ -56,17 +61,19 @@ public class QuittableChrome extends DevToolsDriver {
     activate();
     enablePageEvents();
     enableRuntimeEvents();
-    enableNetworkEvents();
+    if (trackNetworkFailures) {
+      enableNetworkEvents();
+    }
     if (!options.headless) {
       initWindowIdAndState();
     }
   }
 
   public static QuittableChrome prepareAndStart() {
-    return prepareAndStart(null);
+    return prepareAndStart(null, false);
   }
 
-  public static QuittableChrome prepareAndStart(final Map<String, Object> map) {
+  public static QuittableChrome prepareAndStart(final Map<String, Object> map, final boolean trackNetworkFailures) {
     final Map<String, Object> props = new HashMap<>();
     if (map != null) {
       props.putAll(map);
@@ -88,7 +95,7 @@ public class QuittableChrome extends DevToolsDriver {
     final Response res = http.path("json", "new").put(null);
 
     final String webSocketUrl = res.json().get("$.webSocketDebuggerUrl");
-    return new QuittableChrome(res, options, null, webSocketUrl);
+    return new QuittableChrome(res, options, null, webSocketUrl, trackNetworkFailures);
   }
 
   private static synchronized ScenarioRuntime createRuntime() {
@@ -110,18 +117,23 @@ public class QuittableChrome extends DevToolsDriver {
 
   @Override
   public void receive(final DevToolsMessage dtm) {
-    if (dtm.methodIs("Network.requestWillBeSent")) {
-      networkFailureTracker.onRequest(dtm.getParam("requestId"), dtm.getParam("request.url"), dtm.getParam("request.method"));
-    } else if (dtm.methodIs("Network.responseReceived")) {
-      networkFailureTracker.onResponse(dtm.getParam("requestId"), dtm.getParam("response.status"));
-    } else if (dtm.methodIs("Network.loadingFailed")) {
-      networkFailureTracker.onLoadingFailed(dtm.getParam("requestId"), dtm.getParam("errorText"), dtm.getParam("type"),
-          dtm.getParam("canceled"));
+    if (trackNetworkFailures) {
+      if (dtm.methodIs("Network.requestWillBeSent")) {
+        networkFailureTracker.onRequest(dtm.getParam("requestId"), dtm.getParam("request.url"), dtm.getParam("request.method"));
+      } else if (dtm.methodIs("Network.responseReceived")) {
+        networkFailureTracker.onResponse(dtm.getParam("requestId"), dtm.getParam("response.status"));
+      } else if (dtm.methodIs("Network.loadingFailed")) {
+        networkFailureTracker.onLoadingFailed(dtm.getParam("requestId"), dtm.getParam("errorText"), dtm.getParam("type"),
+            dtm.getParam("canceled"));
+      }
     }
     super.receive(dtm);
   }
 
   public List<NetworkFailure> getNetworkFailures() {
+    if (!trackNetworkFailures) {
+      return List.of();
+    }
     return networkFailureTracker.getFailures(this::tryFetchResponseBody);
   }
 

--- a/src/main/java/nl/aerius/print/QuittableChrome.java
+++ b/src/main/java/nl/aerius/print/QuittableChrome.java
@@ -119,7 +119,8 @@ public class QuittableChrome extends DevToolsDriver {
   public void receive(final DevToolsMessage dtm) {
     if (trackNetworkFailures) {
       if (dtm.methodIs("Network.requestWillBeSent")) {
-        networkFailureTracker.onRequest(dtm.getParam("requestId"), dtm.getParam("request.url"), dtm.getParam("request.method"));
+        networkFailureTracker.onRequest(dtm.getParam("requestId"), dtm.getParam("request.url"), dtm.getParam("request.method"),
+            dtm.getParam("request.headers.Referer"));
       } else if (dtm.methodIs("Network.responseReceived")) {
         networkFailureTracker.onResponse(dtm.getParam("requestId"), dtm.getParam("response.status"));
       } else if (dtm.methodIs("Network.loadingFailed")) {

--- a/src/main/java/nl/aerius/print/QuittableChrome.java
+++ b/src/main/java/nl/aerius/print/QuittableChrome.java
@@ -17,6 +17,7 @@
 package nl.aerius.print;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import com.intuit.karate.core.Scenario;
 import com.intuit.karate.core.ScenarioEngine;
 import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.driver.DevToolsDriver;
+import com.intuit.karate.driver.DevToolsMessage;
 import com.intuit.karate.driver.DriverOptions;
 import com.intuit.karate.http.HttpClientFactory;
 import com.intuit.karate.http.Response;
@@ -42,6 +44,7 @@ public class QuittableChrome extends DevToolsDriver {
   private static final Logger LOG = LoggerFactory.getLogger(QuittableChrome.class);
 
   private final String id;
+  private final NetworkFailureTracker networkFailureTracker = new NetworkFailureTracker();
 
   public QuittableChrome(final Response res, final DriverOptions options, final Command command, final String webSocketUrl) {
     super(options, command, webSocketUrl);
@@ -53,6 +56,7 @@ public class QuittableChrome extends DevToolsDriver {
     activate();
     enablePageEvents();
     enableRuntimeEvents();
+    enableNetworkEvents();
     if (!options.headless) {
       initWindowIdAndState();
     }
@@ -102,6 +106,40 @@ public class QuittableChrome extends DevToolsDriver {
       ScenarioEngine.set(engine);
     }
     return ScenarioEngine.get().runtime;
+  }
+
+  @Override
+  public void receive(final DevToolsMessage dtm) {
+    if (dtm.methodIs("Network.requestWillBeSent")) {
+      networkFailureTracker.onRequest(dtm.getParam("requestId"), dtm.getParam("request.url"), dtm.getParam("request.method"));
+    } else if (dtm.methodIs("Network.responseReceived")) {
+      networkFailureTracker.onResponse(dtm.getParam("requestId"), dtm.getParam("response.status"));
+    } else if (dtm.methodIs("Network.loadingFailed")) {
+      networkFailureTracker.onLoadingFailed(dtm.getParam("requestId"), dtm.getParam("errorText"), dtm.getParam("type"),
+          dtm.getParam("canceled"));
+    }
+    super.receive(dtm);
+  }
+
+  public List<NetworkFailure> getNetworkFailures() {
+    return networkFailureTracker.getFailures(this::tryFetchResponseBody);
+  }
+
+  private String tryFetchResponseBody(final String requestId) {
+    if (requestId == null) {
+      return null;
+    }
+    try {
+      final DevToolsMessage dtm = method("Network.getResponseBody").param("requestId", requestId).send();
+      final Boolean base64Encoded = dtm.getResultVariable("base64Encoded").getValue();
+      if (Boolean.TRUE.equals(base64Encoded)) {
+        return "<base64-encoded binary content>";
+      }
+      return dtm.getResultVariable("body").getValue();
+    } catch (final RuntimeException e) {
+      LOG.trace("Could not fetch response body for requestId={}: {}", requestId, e.getMessage());
+      return null;
+    }
   }
 
   @Override

--- a/src/test/java/nl/aerius/print/NetworkFailureTrackingIT.java
+++ b/src/test/java/nl/aerius/print/NetworkFailureTrackingIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.print;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that verifies network failure tracking against a real Chrome instance.
+ *
+ * <p>Requires a local test server and Chrome. Run in order:
+ * <ol>
+ *   <li>{@code node test-server.js}</li>
+ *   <li>{@code google-chrome --headless --remote-debugging-port=9222 --no-first-run --disable-gpu --remote-allow-origins=*}</li>
+ *   <li>{@code mvn verify -Dit.test=NetworkFailureTrackingIT}</li>
+ * </ol>
+ *
+ * <p>The test server (test-server.js in the project root) serves a page that triggers
+ * both network-level failures and HTTP error responses (500, 403) with bodies.
+ */
+class NetworkFailureTrackingIT {
+
+  /**
+   * Navigates to the test server page which triggers:
+   * <ul>
+   *   <li>A fetch to a dead port (network-level failure)</li>
+   *   <li>A fetch to /error (HTTP 500 with text body)</li>
+   *   <li>A fetch to /forbidden (HTTP 403 with HTML body)</li>
+   * </ul>
+   * Verifies that all failures are captured with the expected data.
+   */
+  @Test
+  void networkFailureIsCaptured() throws InterruptedException {
+    final Map<String, Object> options = Map.of(
+        "start", false,
+        "headless", true);
+
+    final QuittableChrome chrome = QuittableChrome.prepareAndStart(options);
+    try {
+      // Navigate to local test server that serves a page making same-origin fetches:
+      // /error - 500 with text body
+      // /forbidden - 403 with HTML body
+      // Also fetches http://localhost:1/dead-port for a network-level failure
+      chrome.setUrl("http://localhost:3456/");
+
+      // Give Chrome time to process the network events
+      Thread.sleep(2000);
+
+      final List<NetworkFailure> failures = chrome.getNetworkFailures();
+
+      System.out.println("Captured " + failures.size() + " network failure(s):");
+      for (final NetworkFailure failure : failures) {
+        System.out.println("  url=" + failure.url()
+            + " method=" + failure.method()
+            + " error=" + failure.errorText()
+            + " type=" + failure.resourceType()
+            + " canceled=" + failure.canceled()
+            + " status=" + failure.responseStatus()
+            + " body=" + failure.responseBody());
+      }
+
+      assertFalse(failures.isEmpty(), "Expected at least one network failure from fetch to dead port");
+    } finally {
+      chrome.quit();
+    }
+  }
+}

--- a/src/test/java/nl/aerius/print/NetworkFailureTrackingIT.java
+++ b/src/test/java/nl/aerius/print/NetworkFailureTrackingIT.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,6 +48,7 @@ class NetworkFailureTrackingIT {
    * </ul>
    * Verifies that all failures are captured with the expected data.
    */
+  @Disabled("Requires a running Chrome instance and test server - run manually")
   @Test
   void networkFailureIsCaptured() throws InterruptedException {
     final Map<String, Object> options = Map.of(

--- a/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
+++ b/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
@@ -17,27 +17,30 @@
 package nl.aerius.print;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
+import java.net.Socket;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Integration test that verifies network failure tracking against a real Chrome instance.
+ * Skips automatically when Chrome or the test server are not available.
  *
- * <p>Requires a local test server and Chrome. Run in order:
+ * <p>To run, start in order:
  * <ol>
  *   <li>{@code node test-server.js}</li>
  *   <li>{@code google-chrome --headless --remote-debugging-port=9222 --no-first-run --disable-gpu --remote-allow-origins=*}</li>
- *   <li>{@code mvn verify -Dit.test=NetworkFailureTrackingIT}</li>
+ *   <li>{@code mvn test -Dtest=NetworkFailureTrackingTest}</li>
  * </ol>
  *
  * <p>The test server (test-server.js in the project root) serves a page that triggers
  * both network-level failures and HTTP error responses (500, 403) with bodies.
  */
-class NetworkFailureTrackingIT {
+class NetworkFailureTrackingTest {
 
   /**
    * Navigates to the test server page which triggers:
@@ -48,9 +51,11 @@ class NetworkFailureTrackingIT {
    * </ul>
    * Verifies that all failures are captured with the expected data.
    */
-  @Disabled("Requires a running Chrome instance and test server - run manually")
   @Test
   void networkFailureIsCaptured() throws InterruptedException {
+    assumeTrue(isPortOpen(9222), "Chrome not running on port 9222");
+    assumeTrue(isPortOpen(3456), "Test server not running on port 3456");
+
     final Map<String, Object> options = Map.of(
         "start", false,
         "headless", true);
@@ -79,9 +84,17 @@ class NetworkFailureTrackingIT {
             + " body=" + failure.responseBody());
       }
 
-      assertFalse(failures.isEmpty(), "Expected at least one network failure from fetch to dead port");
+      assertFalse(failures.isEmpty(), "Expected at least one network failure");
     } finally {
       chrome.quit();
+    }
+  }
+
+  private static boolean isPortOpen(final int port) {
+    try (Socket socket = new Socket("localhost", port)) {
+      return true;
+    } catch (final IOException e) {
+      return false;
     }
   }
 }

--- a/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
+++ b/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
@@ -60,7 +60,7 @@ class NetworkFailureTrackingTest {
         "start", false,
         "headless", true);
 
-    final QuittableChrome chrome = QuittableChrome.prepareAndStart(options);
+    final QuittableChrome chrome = QuittableChrome.prepareAndStart(options, true);
     try {
       // Navigate to local test server that serves a page making same-origin fetches:
       // /error - 500 with text body

--- a/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
+++ b/src/test/java/nl/aerius/print/NetworkFailureTrackingTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration test that verifies network failure tracking against a real Chrome instance.
@@ -41,6 +43,8 @@ import org.junit.jupiter.api.Test;
  * both network-level failures and HTTP error responses (500, 403) with bodies.
  */
 class NetworkFailureTrackingTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NetworkFailureTrackingTest.class);
 
   /**
    * Navigates to the test server page which triggers:
@@ -73,15 +77,12 @@ class NetworkFailureTrackingTest {
 
       final List<NetworkFailure> failures = chrome.getNetworkFailures();
 
-      System.out.println("Captured " + failures.size() + " network failure(s):");
+      LOG.info("Captured {} network failure(s):", failures.size());
       for (final NetworkFailure failure : failures) {
-        System.out.println("  url=" + failure.url()
-            + " method=" + failure.method()
-            + " error=" + failure.errorText()
-            + " type=" + failure.resourceType()
-            + " canceled=" + failure.canceled()
-            + " status=" + failure.responseStatus()
-            + " body=" + failure.responseBody());
+        LOG.info("  url={} method={} error={} type={} canceled={} status={} referer={} body={}",
+            failure.url(), failure.method(), failure.errorText(),
+            failure.resourceType(), failure.canceled(),
+            failure.responseStatus(), failure.referer(), failure.responseBody());
       }
 
       assertFalse(failures.isEmpty(), "Expected at least one network failure");

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,20 @@
+const http = require('http');
+http.createServer((req, res) => {
+  if (req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<html><script>
+      fetch('/error').catch(e => {});
+      fetch('/forbidden').catch(e => {});
+      fetch('http://localhost:1/dead-port').catch(e => {});
+    </script></html>`);
+  } else if (req.url === '/error') {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Something went wrong: detailed error message from server');
+  } else if (req.url === '/forbidden') {
+    res.writeHead(403, { 'Content-Type': 'text/html' });
+    res.end('<html><body><h1>Forbidden</h1><p>Your request was blocked by policy.</p></body></html>');
+  } else {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+  }
+}).listen(3456, () => console.log('Test server on http://localhost:3456'));


### PR DESCRIPTION
This adds failure diagnostics backward compatibly: when failures occur, it dumps network diagnostics to LOG, including URL, error text, status code, and response body.

Re: the test, it's basically fake and meant to be run manually, won't ever work in a CI environment and thus will always succeed